### PR TITLE
Init Keycloak with configuration object

### DIFF
--- a/security/init.js
+++ b/security/init.js
@@ -3,7 +3,10 @@ import store from '../'
 
 let keycloakAuth = new Keycloak('/statics/keycloak.json')
 
-export default (next, roles) => {
+export default (next, roles, conf) => {
+  if (conf) {
+    keycloakAuth = new Keycloak(conf);
+  }
   keycloakAuth.init({ onLoad: 'login-required' })
     .success((authenticated) => {
       if (!authenticated) {


### PR DESCRIPTION
This change enables users to init Keycloak with a dynamic configuration object (instead of one static json file).

```js
const KC_CONF = {
  DEV: {
    url: 'auth-server-url',
    clientId: 'myDevCient',
    realm: 'myDevRealm'
  },
  PROD: {
    url: 'auth-server-url',
    clientId: 'myProductionClient',
    realm: 'myProductionRealm'
  }
}

router.beforeEach((to, from, next) => {
  if (to.meta.requiresAuth) {
    const auth = store.state.security.auth
    if (!auth.authenticated) {
      security.init(next, to.meta.roles, KC_CONF[process.env.VUE_APP_ENV])
    }
    else {
      if (to.meta.roles) {
        if (security.roles(to.meta.roles[0])) {
          next()
        }
        else {
          next({ name: 'unauthorized' })
        }
      }
      else {
        next()
      }
    }
  }
  else {
    next()
  }
})
```

